### PR TITLE
Fix user with ROLE_ADMIN without specific permissions.

### DIFF
--- a/src/composables/system/ability.ts
+++ b/src/composables/system/ability.ts
@@ -39,9 +39,9 @@ export function useAcl() {
 
   const can = (acl: AclValue, subject?: object): boolean => {
     if (!hasCurrentUser()) return false
+    if (currentUserIsSuperAdmin.value) return true
     const permission = currentUser.value?.resolvedPermissions[acl]
     if (isUndefined(permission)) return false
-    if (currentUserIsSuperAdmin.value) return true
     if (
       isNotUndefined(currentExtSystemId.value) &&
       !aclsNotAlwaysAllowedForExtSystemAdmin.includes(acl) &&


### PR DESCRIPTION
User with ROLE_ADMIN should not be required to have specific permissions, since they are irrelevant.