### PR TITLE
fix(author): order author list by createdAt instead of id

### DIFF
--- a/src/views/coreDam/author/composables/authorActions.ts
+++ b/src/views/coreDam/author/composables/authorActions.ts
@@ -25,7 +25,7 @@ export const useAuthorListActions = () => {
 
   const fetchList = async (pagination: Pagination, filterBag: FilterBag) => {
     listLoading.value = true
-    pagination.sortBy = filterBag.text.model ? null : 'id'
+    pagination.sortBy = filterBag.text.model ? null : 'createdAt'
     try {
       listItems.value = await fetchAuthorList(currentExtSystemId.value, pagination, filterBag)
     } catch (error) {
@@ -163,7 +163,7 @@ export const useAuthorSelectActions = () => {
   }
 
   const fetchItems = async (pagination: Pagination, filterBag: FilterBag) => {
-    pagination.sortBy = filterBag.text.model ? null : 'id'
+    pagination.sortBy = filterBag.text.model ? null : 'createdAt'
 
     return mapToValueObjects(await fetchAuthorList(currentExtSystemId.value, pagination, filterBag))
   }


### PR DESCRIPTION
fetchList hard-set pagination.sortBy to 'id', overriding the ordering dropdown (whose default variant already sorts by createdAt) and forcing the list into UUID order, which buried the newest authors. Default to createdAt desc, respect explicit createdAt asc/desc picks, and keep relevance ordering for fulltext search.